### PR TITLE
Fix doc links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If submitting a **pull request** (bugfix/addition):
 
 ## Making Changes
 
-- Before making any changes, refer to the [DuckDuckHack Styleguide](https://dukgo.com/code_styleguide) to ensure your changes are made in the correct fashion
+- Before making any changes, refer to the [DuckDuckHack Styleguide](https://duck.co/duckduckhack/code_styleguide) to ensure your changes are made in the correct fashion
 - Make sure your commits are of a reasonable size. They shouldn't be too big (or too small)
 - Make sure your commit messages effectively explain what changes have been made, and please identify which Instant Answer or file has been modified:
 

--- a/backend-reference/language-location-apis.md
+++ b/backend-reference/language-location-apis.md
@@ -41,7 +41,7 @@ my $location = join(", ", $loc->city, $loc->region_name, $loc->country_name);
 # "Phoenixville, Pennsylvania, United States"
 ```
 
-For assistance with specifying the location to be used in automated testing, please refer to the [Location API testing guide](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/testing/testing_location_language_apis.md).
+For assistance with specifying the location to be used in automated testing, please refer to the [Location API testing guide](../testing-reference/testing_location_language_apis.md).
 
 Naturally, once your Instant Answer is live, `$loc` will refer to the appropriate location.
 
@@ -73,4 +73,4 @@ Example data from `$lang`:
 
 When testing interactively with `duckpan`, the locale will always be set to `en_US`.
 
-It is possible to set different locales when running automated tests. Please refer to the [Language API testing guide](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/testing/testing_location_language_apis.md) for more information.
+It is possible to set different locales when running automated tests. Please refer to the [Language API testing guide](../testing-reference/testing_location_language_apis.md) for more information.

--- a/backend-reference/spice-attributes.md
+++ b/backend-reference/spice-attributes.md
@@ -34,7 +34,7 @@ If the API used for your Instant Answer does not support JSONP (ie. it doesn't p
 
 ## Spice `proxy_cache_valid `
 
-(Know what should go here? Then **please** [contribute to the documentation](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/CONTRIBUTING.md)!)
+(Know what should go here? Then **please** [contribute to the documentation](../CONTRIBUTING.md)!)
 
 ## Spice `is_unsafe`
 

--- a/ddh-intro.md
+++ b/ddh-intro.md
@@ -20,11 +20,11 @@ Learn to make an Instant Answer by starting with any of our quick tutorials. All
 
 We welcome new contributors to dive in and improve live Instant Answers. It's a great, hands-on way to learn how things work. Start by [setting up your development environment](http://docs.duckduckhack.com/welcome/setup-dev-environment.html).
 
-Have a [favorite Instant Answer](http://duck.co/ia) that you want to make even better? Feel free to dive in. 
+Have a [favorite Instant Answer](http://duck.co/ia) that you want to make even better? Feel free to dive in.
 
-We also make sure to identify "low-hanging fruit" for new community members to work on. 
+We also make sure to identify "low-hanging fruit" for new community members to work on.
 
-- [Goodie Low Hanging Fruit](https://github.com/duckduckgo/zeroclickinfo-goodies/issues?q=is%3Aopen+is%3Aissue+label%3A%22Low-Hanging+Fruit%22) (Instant Answers that **do not** make external calls) 
+- [Goodie Low Hanging Fruit](https://github.com/duckduckgo/zeroclickinfo-goodies/issues?q=is%3Aopen+is%3Aissue+label%3A%22Low-Hanging+Fruit%22) (Instant Answers that **do not** make external calls)
 - [Spice Low Hanging Fruit](https://github.com/duckduckgo/zeroclickinfo-spice/issues?q=is%3Aopen+is%3Aissue+label%3A%22Low-Hanging+Fruit%22) (Instant Answers that call external APIs)
 
 ## Inspiration
@@ -39,7 +39,7 @@ Instant Answers can be quite dynamic...
 
 ![](http://docs.duckduckhack.com/assets/sales_tax.png)
 
-Some are just cool: 
+Some are just cool:
 
 ![](http://docs.duckduckhack.com/assets/heads_tails.png)
 
@@ -67,7 +67,7 @@ The [possibilities are endless](https://duck.co/ia). **Our community's mission i
 
 ## Discuss with Us
 
-Want help? Need to think out loud? 
+Want help? Need to think out loud?
 
 [![slack](http://docs.duckduckhack.com/assets/slack.png) Talk to us on Slack](mailto:QuackSlack@duckduckgo.com?subject=AddMe) or [email us](mailto:open@duckduckgo.com).
 

--- a/ddh-intro.md
+++ b/ddh-intro.md
@@ -73,4 +73,4 @@ Want help? Need to think out loud?
 
 We're a digital community, but real people - we frequently meet up to hack together. Check out our [global meetups](http://duckduckgo.meetup.com/).
 
-*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github](https://github.com/duckduckgo/duckduckgo-documentation).*
+*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github](https://github.com/duckduckgo/duckduckhack-docs).*

--- a/frontend-reference/accessing-query-remainder.md
+++ b/frontend-reference/accessing-query-remainder.md
@@ -45,4 +45,4 @@ var matches = source.match(/example_answer\/([^\/]+)\/([^\/]+)/),
     partTwo = matches[2]; // equals "term2"
 ```
 
-(More for this section is coming soon! Know what should go here? Then **please** [contribute to the documentation](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/CONTRIBUTING.md)!)
+(More for this section is coming soon! Know what should go here? Then **please** [contribute to the documentation](../CONTRIBUTING.md)!)

--- a/testing-reference/test-files.md
+++ b/testing-reference/test-files.md
@@ -10,7 +10,7 @@ Every Instant Answer must include a test file in the repository's `t` directory.
 - trigger on the expected queries, and
 - provide appropriate answers for the queries handled.
 
-At a minimum, your tests should cover all of your primary and secondary example queries. If possible, you should also include examples of similar queries on which your code does **not** trigger. 
+At a minimum, your tests should cover all of your primary and secondary example queries. If possible, you should also include examples of similar queries on which your code does **not** trigger.
 
 If your answer depends on the user's location, please review the [Location API testing guide](../testing-reference/testing_location_language_apis.md) for help in developing your tests. If your answer depends on the time of day or year, please be sure that your tests will continue to pass no matter when they are run.
 

--- a/testing-reference/test-files.md
+++ b/testing-reference/test-files.md
@@ -12,7 +12,7 @@ Every Instant Answer must include a test file in the repository's `t` directory.
 
 At a minimum, your tests should cover all of your primary and secondary example queries. If possible, you should also include examples of similar queries on which your code does **not** trigger. 
 
-If your answer depends on the user's location, please review the [Location API testing guide](https://github.com/duckduckgo/duckduckgo-documentation/blob/master/testing/testing_language_location_apis.md) for help in developing your tests. If your answer depends on the time of day or year, please be sure that your tests will continue to pass no matter when they are run.
+If your answer depends on the user's location, please review the [Location API testing guide](../testing-reference/testing_location_language_apis.md) for help in developing your tests. If your answer depends on the time of day or year, please be sure that your tests will continue to pass no matter when they are run.
 
 ## Creating Test Files
 


### PR DESCRIPTION
There are two links in the testing-triggers.md file that still point to the old repository:

```
https://github.com/duckduckgo/duckduckgo-documentation/blob/master/goodie/goodie_basic_tutorial.md
https://github.com/duckduckgo/duckduckgo-documentation/blob/master/spice/spice_basic_tutorial.md
```

I could not find any equivalent files in this new repository so I left them as is.

Also, my editor fixed a bunch of whitespace in the files I touched. If needed I can remove that whitespace commit from this pull request.
