### PR TITLE
Add/improve links to PRs and issues

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,6 +4,6 @@ Welcome to the DuckDuckHack documentation repository. We welcome contributions t
 
 The readable version of these docs [can be found here](http://docs.duckduckhack.com).
 
-If you've noticed any opportunities for improvement - from making the docs clearer to typos - feel free to create a GitHub issue, or go ahead and make the changes and submit a pull request.
+If you've noticed any opportunities for improvement - from making the docs clearer to typos - feel free to [create a GitHub issue](https://github.com/duckduckgo/duckduckhack-docs/issues/new), or go ahead and make the changes and submit a [pull request](https://github.com/duckduckgo/duckduckhack-docs/pulls).
 
 [![slack](http://docs.duckduckhack.com/assets/slack.png) Talk to us anytime on Slack](mailto:QuackSlack@duckduckgo.com?subject=AddMe) or [email us](mailto:open@duckduckgo.com).

--- a/ddh-intro.md
+++ b/ddh-intro.md
@@ -80,4 +80,4 @@ Want help? Need to think out loud? There are several ways to get in touch with s
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
 
 
-*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*
+*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs/issues/new).*

--- a/resources/get-in-touch.md
+++ b/resources/get-in-touch.md
@@ -10,4 +10,4 @@ Want help? Need to think out loud? There are several ways to get in touch with s
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
 
 
-*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*
+*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs/issues/new).*

--- a/welcome/determining-ia-type.md
+++ b/welcome/determining-ia-type.md
@@ -56,4 +56,4 @@ Want help? Need to think out loud? There are several ways to get in touch with s
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
 
 
-*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*
+*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs/issues/new).*

--- a/welcome/how-ias-work.md
+++ b/welcome/how-ias-work.md
@@ -99,4 +99,4 @@ Want help? Need to think out loud? There are several ways to get in touch with s
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
 
 
-*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*
+*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs/new).*

--- a/welcome/setup-dev-environment.md
+++ b/welcome/setup-dev-environment.md
@@ -170,4 +170,4 @@ Want help? Need to think out loud? There are several ways to get in touch with s
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
 
 
-*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*
+*P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs/issues/new).*


### PR DESCRIPTION
Point some of the `create an issue...` links to `issues/new`, which will open the new issue interface.

Add issue/pr link to README.

Could point appropriate PR mentions to `/compare`, but this assumes they already have the stuff needed to perform a PR.
