### PR TITLE
Stop linking to Freenode Webchat

### DIFF
--- a/ddh-intro.md
+++ b/ddh-intro.md
@@ -73,11 +73,11 @@ The [possibilities are endless](https://duck.co/ia). **Our community's mission i
 Want help? Need to think out loud? There are several ways to get in touch with staff, leaders, and community members. We look forward to hearing from you!
 
 - **Slack**: Join our organization on Slack by [emailing us](mailto:QuackSlack@duckduckgo.com?subject=AddMe). We should respond within a day.
-- **IRC**: Fastest way to join in the conversation: [#DuckDuckGo channel](http://webchat.freenode.net/?channels=duckduckgo)
 - **Mailing list**: [Get our developer newsletter](https://www.listbox.com/subscribe/?list_id=197814) (low traffic)
 - **Meet Up**: Meet us at a [DuckDuckHack MeetUp group near you](http://www.meetup.com/pro/duckduckgo/) - or start a new one.
 - **Twitter**: Tweet at us [@DuckDuckHack](https://twitter.com/duckduckhack/)
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
+- **IRC**: #duckduckgo on freenode
 
 
 *P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*

--- a/resources/get-in-touch.md
+++ b/resources/get-in-touch.md
@@ -3,11 +3,11 @@
 Want help? Need to think out loud? There are several ways to get in touch with staff, leaders, and community members. We look forward to hearing from you!
 
 - **Slack**: Join our organization on Slack by [emailing us](mailto:QuackSlack@duckduckgo.com?subject=AddMe). We should respond within a day.
-- **IRC**: Fastest way to join in the conversation: [#DuckDuckGo channel](http://webchat.freenode.net/?channels=duckduckgo)
 - **Mailing list**: [Get our developer newsletter](https://www.listbox.com/subscribe/?list_id=197814) (low traffic)
 - **Meet Up**: Meet us at a [DuckDuckHack MeetUp group near you](http://www.meetup.com/pro/duckduckgo/) - or start a new one.
 - **Twitter**: Tweet at us [@DuckDuckHack](https://twitter.com/duckduckhack/)
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
+- **IRC**: #duckduckgo on freenode
 
 
 *P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*

--- a/welcome/determining-ia-type.md
+++ b/welcome/determining-ia-type.md
@@ -49,11 +49,11 @@ For more on Longtail Instant Answers, see the [Longtail overview](http://docs.du
 Want help? Need to think out loud? There are several ways to get in touch with staff, leaders, and community members. We look forward to hearing from you!
 
 - **Slack**: Join our organization on Slack by [emailing us](mailto:QuackSlack@duckduckgo.com?subject=AddMe). We should respond within a day.
-- **IRC**: Fastest way to join in the conversation: [#DuckDuckGo channel](http://webchat.freenode.net/?channels=duckduckgo)
 - **Mailing list**: [Get our developer newsletter](https://www.listbox.com/subscribe/?list_id=197814) (low traffic)
 - **Meet Up**: Meet us at a [DuckDuckHack MeetUp group near you](http://www.meetup.com/pro/duckduckgo/) - or start a new one.
 - **Twitter**: Tweet at us [@DuckDuckHack](https://twitter.com/duckduckhack/)
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
+- **IRC**: #duckduckgo on freenode
 
 
 *P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*

--- a/welcome/how-ias-work.md
+++ b/welcome/how-ias-work.md
@@ -92,11 +92,11 @@ Don't worry about getting this right. By making use of the `duckpan new` command
 Want help? Need to think out loud? There are several ways to get in touch with staff, leaders, and community members. We look forward to hearing from you!
 
 - **Slack**: Join our organization on Slack by [emailing us](mailto:QuackSlack@duckduckgo.com?subject=AddMe). We should respond within a day.
-- **IRC**: Fastest way to join in the conversation: [#DuckDuckGo channel](http://webchat.freenode.net/?channels=duckduckgo)
 - **Mailing list**: [Get our developer newsletter](https://www.listbox.com/subscribe/?list_id=197814) (low traffic)
 - **Meet Up**: Meet us at a [DuckDuckHack MeetUp group near you](http://www.meetup.com/pro/duckduckgo/) - or start a new one.
 - **Twitter**: Tweet at us [@DuckDuckHack](https://twitter.com/duckduckhack/)
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
+- **IRC**: #duckduckgo on freenode
 
 
 *P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*

--- a/welcome/setup-dev-environment.md
+++ b/welcome/setup-dev-environment.md
@@ -163,11 +163,11 @@ Now we'll put it all together - we'll bring the code we forked on Github onto th
 Want help? Need to think out loud? There are several ways to get in touch with staff, leaders, and community members. We look forward to hearing from you!
 
 - **Slack**: Join our organization on Slack by [emailing us](mailto:QuackSlack@duckduckgo.com?subject=AddMe). We should respond within a day.
-- **IRC**: Fastest way to join in the conversation: [#DuckDuckGo channel](http://webchat.freenode.net/?channels=duckduckgo)
 - **Mailing list**: [Get our developer newsletter](https://www.listbox.com/subscribe/?list_id=197814) (low traffic)
 - **Meet Up**: Meet us at a [DuckDuckHack MeetUp group near you](http://www.meetup.com/pro/duckduckgo/) - or start a new one.
 - **Twitter**: Tweet at us [@DuckDuckHack](https://twitter.com/duckduckhack/)
 - **Email**: You can always send an [email](mailto:open@duckduckgo.com) to [open@duckduckgo.com](mailto:open@duckduckgo.com)
+- **IRC**: #duckduckgo on freenode
 
 
 *P.S. Let us know if we can improve anything in these documents [by opening issues directly on Github]( https://github.com/duckduckgo/duckduckhack-docs).*


### PR DESCRIPTION
- It's the fastest way to get completely ignored - there's no conversation there.
- People who don't understand the async nature of IRC will be disappointed or disillusioned by this (most leave within a minute or two of joining).

Cc: @zekiel 
