### PR TITLE
get started replaced with sign up

### DIFF
--- a/welcome/setup-dev-environment.md
+++ b/welcome/setup-dev-environment.md
@@ -62,7 +62,7 @@ Before we work on the Instant Answer codebase, we first need a development machi
 
 > Already have a Codio Account? Perfect, move on to the next step.
 
-1. Go to https://codio.com and click "**Get Started**", at the top right corner.
+1. Go to https://codio.com and click "**Sign Up**", at the top right corner.
 2. Click "**Sign Up via GitHub**".
 3. If you aren't already signed into GitHub, enter your GitHub login details and then click "**Sign In**".
 4. Click "**Authorize application**" to continue.


### PR DESCRIPTION
Codio no longer has Get Started at the `top right` corner. It's been replaced with `Sign Up`
