### PR TITLE
Spice walkthrough: Changed JS wrapper to match template

### DIFF
--- a/frontend-reference/display-reference.md
+++ b/frontend-reference/display-reference.md
@@ -691,7 +691,7 @@ When setting `sort_fields` properties in a Goodie, you must specify them in the 
 A string specifying the default `sort_field` to be used for initial sorting of the tiles.
 
 ```javascript
-sort_default: 'name';
+sort_default: 'name'
 ```
 
 If you have used **more than one** relevancy block, `sort_default` can be given an `object` specifying the default `sort_field` for each relevancy block.
@@ -806,7 +806,3 @@ An added `item.$html` property references the respective item DOM element as a j
 ### Notes for Goodie Instant Answers
 
 When creating a Goodie, you must declare event handlers in the front end part of the code, as JavaScript. For more information about Goodie JavaScript visit the [Goodie Display](http://docs.duckduckhack.com/frontend-reference/setting-goodie-display.html#setting-goodie-display-properties-in-the-frontend) section.
-
-
-
-

--- a/walkthroughs/forum-lookup.md
+++ b/walkthroughs/forum-lookup.md
@@ -242,7 +242,7 @@ Our JavaScript file is wrapped inside the "[module pattern](http://www.addyosman
 
     // Everything else...
 
-})(this);
+}(this));
 ```
 
 It's not at all critical to understand this, simply that it is required for any Instant Answer front end.


### PR DESCRIPTION
This is the preferred syntax according to @moollaza, following Douglas Crockford's style.
