### PR TITLE
Update Fathead/Longtail docs

### DIFF
--- a/resources/fathead-overview.md
+++ b/resources/fathead-overview.md
@@ -8,21 +8,19 @@ The **output.txt** file that is generated will be consumed by the DuckDuckGo bac
 
 Each Fathead Instant Answer has its own directory, which looks like this:
 
-- ``lib/DDG/Fathead/FatheadName.pm`` &ndash; a Perl file that lists some meta information about the Instant Answer
+- ``lib/fathead/fathead_name/fetch.sh`` &ndash; a shell script called to fetch the data.
 
-- ``share/fathead/fathead_name/fetch.sh`` &ndash; a shell script called to fetch the data.
+- ``lib/fathead/fathead_name/download/`` &ndash; a directory to hold temp files created by fetch.sh
 
-- ``share/fathead/fathead_name/download/`` &ndash; a directory to hold temp files created by fetch.sh
+- ``lib/fathead/fathead_name/parse.xx`` &ndash; the script used to parse the data once it has been fetched. .xx can be .pl, .py, .rb, .js, etc. depending on what language you use.
 
-- ``share/fathead/fathead_name/parse.xx`` &ndash; the script used to parse the data once it has been fetched. .xx can be .pl, .py, .rb, .js, etc. depending on what language you use.
+- ``lib/fathead/fathead_name/parse.sh`` &ndash; a shell script wrapper around parse.xx
 
-- ``share/fathead/fathead_name/parse.sh`` &ndash; a shell script wrapper around parse.xx
+- ``lib/fathead/fathead_name/README.txt`` &ndash; Please include any dependencies here, or other special instructions for people trying to run it. Currently, Fathead Instant Answers require some hand work by DuckDuckGo staff during integration.
 
-- ``share/fathead/fathead_name/README.txt`` &ndash; Please include any dependencies here, or other special instructions for people trying to run it. Currently, Fathead Instant Answers require some hand work by DuckDuckGo staff during integration.
+- ``lib/fathead/fathead_name/output.txt`` &ndash; the output file. It generally should **not** be committed to github, but may be committed if it is small (<1MB).
 
-- ``share/fathead/fathead_name/output.txt`` &ndash; the output file. It generally should **not** be committed to github, but may be committed if it is small (<1MB).
-
-- ``share/fathead/fathead_name/data.url`` &ndash; an optional pointer to a URL in the cloud somewhere, which contains the data to process.
+- ``lib/fathead/fathead_name/data.url`` &ndash; an optional pointer to a URL in the cloud somewhere, which contains the data to process.
 
 
 ## Data File Format

--- a/resources/longtail-overview.md
+++ b/resources/longtail-overview.md
@@ -45,11 +45,6 @@ Longtails are similar in structure to [Fatheads](http://docs.duckduckhack.com/re
     "l4_sec":"Anniversaries, Commemorations, Congress, Congressional tributes, Dental care, Dentistry, Department of Health and Human Services, Government operations and politics, Health, Legislation, Medical research, Research centers, Science, technology, communications",
     "p_count":1,
     "source":"instant_answer_id"
-  },
-  {
-    .
-    .
-    .
   }
 ]
 ```

--- a/resources/longtail-overview.md
+++ b/resources/longtail-overview.md
@@ -4,7 +4,7 @@ Longtails are database-backed, full text search, Instant Answers. For every quer
 
 ## Structure
 
-Longtails consist of two primary files. The first is a metadata file that describes the Instant Answer you are building. Its structure is identical to the Fathead metadata file, described [here](https://github.com/duckduckgo/zeroclickinfo-fathead#meta-file). The second, which can be generated using a language of your choosing, contains the data set in a format ready for us to deploy:
+Longtails are similar in structure to [Fatheads](http://docs.duckduckhack.com/resources/fathead-overview.html#Structure) with respect to downloading and processing the source data. The primary difference is that the final output needs to be XML or JSON in the following formats:
 
 ```XML
 <!-- This XML declaration can be simply copied and is necessary for all longtail. -->
@@ -30,10 +30,28 @@ Longtails consist of two primary files. The first is a metadata file that descri
 <!-- The p_count field is used to break ties on exact title matches. This should be used when the data is too long to be displayed without being broken into separate paragraphs. It can be omitted. -->
 <field name="p_count">1</field>
 
-<!-- The source field contains the address of the data source. If possible, it should reference the particular resource that this snippet was taken from. -->
-<field name="source"><![CDATA[http://www.govtrack.us/]]></field>
+<!-- The source should match the ID from the instant answer page you created - https://duck.co/ia/dev/pipeline -->
+<field name="source"><![CDATA[instant_answer_id]]></field>
 
 </doc>
+```
+
+```JSON
+[
+  {
+    "title":"U.S. House Bill #289",
+    "l2_sec":"Recognizing the 50th anniversary of the National Institute of Dental Research.",
+    "l3_sec":"House Committee on Commerce",
+    "l4_sec":"Anniversaries, Commemorations, Congress, Congressional tributes, Dental care, Dentistry, Department of Health and Human Services, Government operations and politics, Health, Legislation, Medical research, Research centers, Science, technology, communications",
+    "p_count":1,
+    "source":"instant_answer_id"
+  },
+  {
+    .
+    .
+    .
+  }
+]
 ```
 
 (This section is still growing! Know what should go here? Then **please** [contribute to the documentation]( https://github.com/duckduckgo/duckduckhack-docs/)!)


### PR DESCRIPTION
- Not mention the extinct metadata Perl module
- Update the share path to lib
- Add JSON Longtail output
