### PR TITLE
setup-dev-environment.md - Update for codio website changes

### DIFF
--- a/welcome/setup-dev-environment.md
+++ b/welcome/setup-dev-environment.md
@@ -62,11 +62,12 @@ Before we work on the Instant Answer codebase, we first need a development machi
 
 > Already have a Codio Account? Perfect, move on to the next step.
 
-1. Go to https://codio.com and click "**Sign Up**", at the top right corner.
-2. Click "**Sign Up via GitHub**".
-3. If you aren't already signed into GitHub, enter your GitHub login details and then click "**Sign In**".
-4. Click "**Authorize application**" to continue.
-5. In the new screen, enter the required details and click "**Create Account**".
+1. Go to https://codio.com and click "**Free Trial**", at the top right corner.
+2. Select "**Individual**".
+3. Click the "**Sign Up via GitHub**" icon.
+4. If you aren't already signed into GitHub, enter your GitHub login details and then click "**Sign In**".
+5. Click "**Authorize application**" to continue.
+6. In the new screen, enter the required details and click "**Create Account**".
 
 ### 2b. Join the DuckDuckGo Organization on Codio
 

--- a/welcome/setup-dev-environment.md
+++ b/welcome/setup-dev-environment.md
@@ -64,7 +64,7 @@ Before we work on the Instant Answer codebase, we first need a development machi
 
 1. Go to https://codio.com and click "**Free Trial**", at the top right corner.
 2. Select "**Individual**".
-3. Click the "**Sign Up via GitHub**" icon.
+3. Click the green "**Sign Up via GitHub**" icon.
 4. If you aren't already signed into GitHub, enter your GitHub login details and then click "**Sign In**".
 5. Click "**Authorize application**" to continue.
 6. In the new screen, enter the required details and click "**Create Account**".


### PR DESCRIPTION
This commit changes two items in the _2a. Sign Up for a Codio Account_ section.
The changes represent front-end website changes made by Codio on their website.
Firstly, Codio no longer has the menu item "Sign Up" at the top corner. Instead, the menu item now lists "Free Trial".
Secondly, Codio no longer uses the "Sign Up via GitHub" button. Instead, they use a "Sign Up via GitHub" icon.
