### PR TITLE
frontend-reference: Modify cheatsheet reference consecutive keys section

### DIFF
--- a/frontend-reference/cheat-sheet-reference.md
+++ b/frontend-reference/cheat-sheet-reference.md
@@ -266,9 +266,9 @@ We recommend expressing simultaneous key presses as follows:
 - As adjacent code blocks, e.g. `"[Ctrl] [v]"`
 - For "*nix-style" cheat sheets (like Emacs), as a single code block with a dash, e.g. `"[C-v]"`
 
-### Consecutive Keys (e.g., pressing A, then pressing B)
+### Consecutive Keys (e.g., pressing Ctrl+A, then pressing B)
 
-We recommend expressing consecutive key presses as separate code blocks separated by a comma, e.g. `"[Ctrl-B], [x]"`
+We recommend expressing consecutive key presses as separate code blocks separated by a comma, e.g. `"[Ctrl] [A], [B]"`
 
 ### Alternative Keys (e.g., pressing either A or B)
 


### PR DESCRIPTION
The **consecutive keys section under cheatsheet reference (frontend-reference) docs** was a bit
incosistent and confusing to follow. This should be modified to make it
easy to follow.
- consecutive keys section modified

Dev to notify: @GuiltyDolphin , @moollaza 
