### PR TITLE
Searchterm examples fix

### DIFF
--- a/frontend-reference/display-reference.md
+++ b/frontend-reference/display-reference.md
@@ -186,7 +186,6 @@ The following are all properties of the `meta: {}` object.
 
 	- In [news.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/news/news.js#L96), `searchTerm` is passed the search query after some basic cleanup.
 	- In [alternative_to.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/alternative_to/alternative_to.js#L16), `searchTerm` is passed a name provided by the API.
-	- In [songkick_geteventid.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/songkick/geteventid/songkick_geteventid.js#L38), `searchTerm` is passed a city name.
 
 - ### `itemType` *string* [optional]
 

--- a/frontend-reference/display-reference.md
+++ b/frontend-reference/display-reference.md
@@ -184,7 +184,7 @@ The following are all properties of the `meta: {}` object.
 
 	#### Examples
 
-	- In [news.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/news/news.js#L89), `searchTerm` is passed the search query after some basic cleanup.
+	- In [news.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/news/news.js#L96), `searchTerm` is passed the search query after some basic cleanup.
 	- In [images.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/images/images.js#L19), `searchTerm` is passed the original query as-is.
 	- In [alternative_to.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/alternative_to/alternative_to.js#L16), `searchTerm` is passed a name provided by the API.
 	- In [songkick_geteventid.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/songkick/geteventid/songkick_geteventid.js#L38), `searchTerm` is passed a city name.

--- a/frontend-reference/display-reference.md
+++ b/frontend-reference/display-reference.md
@@ -185,7 +185,6 @@ The following are all properties of the `meta: {}` object.
 	#### Examples
 
 	- In [news.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/news/news.js#L96), `searchTerm` is passed the search query after some basic cleanup.
-	- In [images.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/images/images.js#L19), `searchTerm` is passed the original query as-is.
 	- In [alternative_to.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/alternative_to/alternative_to.js#L16), `searchTerm` is passed a name provided by the API.
 	- In [songkick_geteventid.js](https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/songkick/geteventid/songkick_geteventid.js#L38), `searchTerm` is passed a city name.
 


### PR DESCRIPTION
Examples for `meta->searchTerm` were faulty. One was pointing to a wrong line number (probably due to update in IA), second one was pointing to a file not using `searchTerm` and the third one was pointing to a file which doesn't exist now.
