### PR TITLE
replace --template cheatsheet with --cheatsheet

### DIFF
--- a/frontend-reference/cheat-sheet-reference.md
+++ b/frontend-reference/cheat-sheet-reference.md
@@ -32,19 +32,21 @@ That means there's no need to create a new Instant Answer. There is also no need
 
 ## Easily Generate a Cheat Sheet Boilerplate File
 
-[The `duckpan` tool](http://docs.duckduckhack.com/resources/duckpan-overview.html) helps make and test Instant Answers. To conveniently create the boilerplate specific to a cheatsheet, run **`duckpan new --template cheatsheet`**:
+[The `duckpan` tool](http://docs.duckduckhack.com/resources/duckpan-overview.html) helps make and test Instant Answers. To conveniently create the boilerplate specific to a cheatsheet, run **`duckpan new --cheatsheet`**:
 
 ```
-[01:08 PM codio@border-carlo zeroclickinfo-goodies {master}]$ duckpan new --template cheatsheet
+[01:08 PM codio@border-carlo zeroclickinfo-goodies {master}]$ duckpan new --cheatsheet
+Creating a new Cheat Sheet Instant Answer...
 Please enter a name for your Instant Answer:
 ```
 
 Type the name of your cheat sheet. The tool will do the rest:
 
 ```
-Please enter a name for your Instant Answer: regex                                                                                
-Created files:                                                                                                                        
-    share/goodie/cheat_sheets/json/regex.json                                                                                        
+Creating a new Cheat Sheet Instant Answer...
+Please enter a name for your Instant Answer: regex1
+Created files:
+    share/goodie/cheat_sheets/json/regex1.json
 Success!
 ```
 

--- a/walkthroughs/programming-syntax.md
+++ b/walkthroughs/programming-syntax.md
@@ -65,16 +65,15 @@ The branch name can be anything you like, for example:
 [08:18 PM codio@border-carlo zeroclickinfo-spice {master}]$ git checkout -b regex1
 ```
 
-[The `duckpan` tool](http://docs.duckduckhack.com/resources/duckpan-overview.html) helps make and test Instant Answers. To create the boilerplate specific to a cheatsheet, run **`duckpan new --template cheatsheet`**:
+[The `duckpan` tool](http://docs.duckduckhack.com/resources/duckpan-overview.html) helps make and test Instant Answers. To create the boilerplate specific to a cheatsheet, run **`duckpan new --cheatsheet`**:
 
 ```
-[01:08 PM codio@border-carlo zeroclickinfo-goodies {regex1}]$ duckpan new --template cheatsheet
+[01:08 PM codio@border-carlo zeroclickinfo-goodies {regex1}]$ duckpan new --cheatsheet
+Creating a new Cheat Sheet Instant Answer...
 Please enter a name for your Instant Answer:
 ```
 
 Type `regex1` (since *regex* already exists in the repository, we'll add a character for this tutorial). If the name contains more than one word, separate them with a space. The tool will do the rest:
-
-> If asked for a 'handler' don't worry about it — just select the default option.
 
 ```
 Please enter a name for your Instant Answer: regex1


### PR DESCRIPTION
It looks like there's a small bug with the `--template cheatsheet` approach where the filename is incorrectly generated with underscores (`_`) instead of dashes (`-`). This approach is also slightly simpler.

I will fix the `--template` method as well so it works as expected

/cc @edgesince84 @tagawa 
