### PR TITLE
Fixes broken query parameter for cards example

### DIFF
--- a/frontend-reference/template-groups.md
+++ b/frontend-reference/template-groups.md
@@ -35,7 +35,7 @@ The [Info](#info-template-group) template group is designed for Instant Answers 
 Examples include:
 
 - [Recipes](https://duckduckgo.com/?q=how+to+mix+a+tom+collins&ia=recipes)
-- [Cards](https://duckduckgo.com/?q=mtg+Boros+Reckoner&ia=magicthegathering)
+- [Cards](https://duckduckgo.com/?q=mtg+Boros+Reckoner&ia=games)
 - [Books](https://duckduckgo.com/?q=book+reviews+moonwalking+with+einstein&ia=books)
 - [Bands](https://duckduckgo.com/?q=weezer+band)
 - [Addresses](https://duckduckgo.com/?q=1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa)


### PR DESCRIPTION
Looks like [this change](https://github.com/duckduckgo/zeroclickinfo-spice/commit/b5b087380ebe4f208860fc43c27e76f989ffe61b#diff-1d9be38ec452e89037df4d1f8ce92dbfL12) just didn't get updated in documentation.
