### PR TITLE
Fix summary link to "Creating Effective Fatheads".

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -51,7 +51,7 @@
    * [The DuckPAN Tool](resources/duckpan-overview.md)
    * [The Screen Diff Tool](resources/screen-diff.md)
    * [Fathead Overview](resources/fathead-overview.md)
-       * [Creating Effective Fatheads](resources/creating-effective-fatheads.md)
+       * [Creating Effective Fatheads](programming-mission/creating-effective-fatheads.md)
    * [Code Style Guide](resources/code-style-guide.md)
    * [Longtail Overview](resources/longtail-overview.md)
    * [Other Development Environments](resources/other-dev-environments.md)


### PR DESCRIPTION
The link in the SUMMARY.md file was not updated when moving the file in commit 7780ed2274c2aa2b21040e074b74b1fd7c890aa8.